### PR TITLE
[#7] Raw Console: Remove floating bubbles and switch to toolbars

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,7 @@ function App() {
                 sendDataToSerialPort: sendDataToSerialPort,
                 serialOutput: serialOutput,
                 serialReady: serialReady,
+                serialTitle: serialTitle,
                 schemas: schemas,
                 config: config,
                 set_config: set_config,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -90,7 +90,11 @@ function App() {
                 </div>
                 <div className="ide-tail">
                     CircuitPy Drive: {statusText} | Serial:{" "}
-                    {serialReady ? (serialTitle ? serialTitle : "Connected") : "No Port Connected"}
+                    {serialReady
+                        ? serialTitle && config.global.serial_status === "title"
+                            ? serialTitle
+                            : "Connected"
+                        : "No Port Connected"}
                 </div>
             </div>
         </ideContext.Provider>

--- a/src/IdeBody.jsx
+++ b/src/IdeBody.jsx
@@ -95,7 +95,10 @@ export default function IdeBody() {
         // tools
         else if (component === "navigation") {
             return (
-                <div className="tab_content" style={fullSize}>
+                <div
+                    className="tab_content"
+                    // TODO style={fullSize} // no idea why this is causing a y-scroll bar
+                >
                     <Navigation />
                 </div>
             );

--- a/src/layout/Menu.jsx
+++ b/src/layout/Menu.jsx
@@ -28,7 +28,7 @@ export default function MenuBar({ menuStructure }) {
     );
 }
 
-function Menu({ label, options }) {
+export function Menu({ label, options }) {
     const [open, setOpen] = React.useState(false);
     const anchorRef = React.useRef(null);
 
@@ -75,6 +75,7 @@ function Menu({ label, options }) {
                 style={{
                     textTransform: "none",
                     color: grey[900],
+                    minWidth: '30px',
                 }}
             >
                 {label}

--- a/src/layout/layout.json
+++ b/src/layout/layout.json
@@ -2,8 +2,7 @@
     "global": {
         "tabEnableClose": true,
         "tabEnableFloat": false,
-        "tabEnableRename": false,
-        "rootOrientationVertical": true
+        "tabEnableRename": false
     },
     "borders": [
         {

--- a/src/layout/layout.json
+++ b/src/layout/layout.json
@@ -2,7 +2,8 @@
     "global": {
         "tabEnableClose": true,
         "tabEnableFloat": false,
-        "tabEnableRename": false
+        "tabEnableRename": false,
+        "rootOrientationVertical": true
     },
     "borders": [
         {
@@ -36,15 +37,7 @@
             "type": "border",
             "location": "bottom",
             "size": 300,
-            "selected": 0,
-            "children": [
-                {
-                    "type": "tab",
-                    "name": "Serial Console",
-                    "component": "serial_raw",
-                    "enableClose": false
-                }
-            ]
+            "children": []
         }
     ],
     "layout": {
@@ -62,7 +55,22 @@
                         "name": "Navigation",
                         "component": "navigation",
                         "enableClose": true
-                    }]
+                    }
+                ]
+            },
+            {
+                "type": "tabset",
+                "id": "initial_tabset_2",
+                "weight": 50,
+                "selected": 0,
+                "children": [
+                    {
+                        "type": "tab",
+                        "name": "Serial Console",
+                        "component": "serial_raw",
+                        "enableClose": false
+                    }
+                ]
             }
         ]
     }

--- a/src/schemas/global.json
+++ b/src/schemas/global.json
@@ -9,6 +9,12 @@
             "type": "string",
             "enum": ["system", "dark", "light"],
             "default": "system"
+        },
+        "serial_status": {
+            "title": "Show in status bar",
+            "type": "string",
+            "enum": ["status", "title"],
+            "default": "status"
         }
     }
 }

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -33,6 +33,10 @@ const useSerial = () => {
                         );
                     }
                 } catch (err) {
+                    setPort(null);
+                    setSerialReady(false);
+                    setSerialOutput("");
+                    setSerialTitle("");
                     console.error("Failed to read data:", err);
                 } finally {
                     reader && reader.releaseLock();
@@ -113,6 +117,7 @@ const useSerial = () => {
         setPort(null);
         setSerialReady(false);
         setSerialOutput("");
+        setSerialTitle("");
     };
 
     return { connectToSerialPort, sendDataToSerialPort, serialOutput, serialReady, serialTitle };

--- a/src/tabs/IdeFolderView.jsx
+++ b/src/tabs/IdeFolderView.jsx
@@ -6,7 +6,6 @@ import ideContext from "../ideContext";
 
 export default function IdeFolderView({ onFileClick, node }) {
     const { openDirectory, directoryReady, rootDirHandle } = useContext(ideContext);
-    console.log(node.getParent());
     // Show FolderView component only when its ready
     return directoryReady ? (
         <div style={{ height: "100%" }}>

--- a/src/tabs/RawConsole.jsx
+++ b/src/tabs/RawConsole.jsx
@@ -36,23 +36,11 @@ const RawSerialIn = () => {
     return <pre style={{ whiteSpace: "pre-wrap", fontSize: config.raw_console.font + "pt" }}>{output}</pre>;
 };
 
-const RawSerialOut = () => {
+const RawSerialOut = ({ text, setText, codeHistIndex, setCodeHistIndex, consoleSendCommand }) => {
     const { config } = useContext(ideContext);
     const aceEditorRef = useRef(null);
-    const [text, setText] = useState("");
-    const [isHovered, toggleHover] = useState(false);
     const { sendCtrlC, sendCtrlD, sendCode, codeHistory } = useSerialCommands();
     const [tempCode, setTempCode] = useState("");
-    const [codeHistIndex, setCodeHistIndex] = useState(-1);
-
-    function consoleSendCommand() {
-        if (text.trim().length === 0) {
-            return;
-        }
-        sendCode(text);
-        setCodeHistIndex(-1);
-        setText("");
-    }
 
     // code history related
     function histUp() {
@@ -181,42 +169,6 @@ const RawSerialOut = () => {
                 }}
                 fontSize={config.raw_console.font + "pt"}
             />
-            <div
-                onMouseEnter={() => {
-                    toggleHover(true);
-                }}
-                onMouseLeave={() => {
-                    toggleHover(false);
-                }}
-            >
-                <Tooltip
-                    title="Send text to microcontroller"
-                    sx={{ position: "absolute", bottom: 16, right: 16, zIndex: 1 }}
-                    followCursor={true}
-                >
-                    <IconButton onClick={consoleSendCommand}>
-                        <SendIcon />
-                    </IconButton>
-                </Tooltip>
-                <Tooltip
-                    title="Send Ctrl-C to microcontroller"
-                    sx={{ position: "absolute", bottom: 46, right: 16, zIndex: 1 }}
-                    followCursor={true}
-                >
-                    <IconButton onClick={sendCtrlC}>
-                        <span style={{ visibility: isHovered ? "visible" : "hidden" }}>Ⓒ</span>
-                    </IconButton>
-                </Tooltip>
-                <Tooltip
-                    title="Send Ctrl-D to microcontroller"
-                    sx={{ position: "absolute", bottom: 76, right: 16, zIndex: 1 }}
-                    followCursor={true}
-                >
-                    <IconButton onClick={sendCtrlD}>
-                        <span style={{ visibility: isHovered ? "visible" : "hidden" }}>Ⓓ</span>
-                    </IconButton>
-                </Tooltip>
-            </div>
         </>
     );
 };
@@ -241,26 +193,63 @@ function ToolbarEntry({ children, fixedWidth = null }) {
 }
 
 const RawConsole = () => {
+    const { sendCtrlC, sendCtrlD, sendCode, codeHistory } = useSerialCommands();
     const { serialReady: ready, connectToSerialPort: connect } = useContext(ideContext);
+    const [text, setText] = useState("");
+    const [codeHistIndex, setCodeHistIndex] = useState(-1);
+    const { serialTitle } = useContext(ideContext);
+
+    function consoleSendCommand() {
+        if (text.trim().length === 0) {
+            return;
+        }
+        sendCode(text);
+        setCodeHistIndex(-1);
+        setText("");
+    }
+
     return ready ? (
         <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
             <div
                 style={{
                     display: "flex",
-                    alignItems: "center",
-                    justifyContent: "left",
+                    justifyContent: "space-between",
+                    borderBottom: "2px solid rgb(239,239,239)",
                     width: "100%",
-                    borderBottomColor: "rgb(239,239,239)",
-                    borderBottom: "solid",
                 }}
             >
-                <Toolbar variant="dense" disableGutters={true} sx={{ minHeight: "35px", maxHeight: "35px" }}>
-                    <ToolbarEntry>hi</ToolbarEntry>
-                </Toolbar>
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "left",
+                        flex: 1,
+                    }}
+                >
+                    {serialTitle}
+                </div>
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "left",
+                    }}
+                >
+                    <Toolbar variant="dense" disableGutters={true} sx={{ minHeight: "35px", maxHeight: "35px" }}>
+                        <ToolbarEntry>
+                            <Tooltip title="Send Ctrl-C to the microcontroller" followCursor={true}>
+                                <Button onClick={sendCtrlC}>Ctrl-C</Button>
+                            </Tooltip>
+                        </ToolbarEntry>
+                        <ToolbarEntry>
+                            <Tooltip title="Send Ctrl-D to the microcontroller" followCursor={true}>
+                                <Button onClick={sendCtrlD}>Ctrl-D</Button>
+                            </Tooltip>
+                        </ToolbarEntry>
+                    </Toolbar>
+                </div>
             </div>
-
             <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "auto" }}>
-                {" "}
                 {/* Ensures B is scrollable if content overflows */}
                 <ScrollableFeed
                     style={{
@@ -275,31 +264,33 @@ const RawConsole = () => {
                 style={{
                     display: "flex",
                     justifyContent: "space-between",
-                    borderTopColor: "rgb(239,239,239)",
-                    borderTop: "solid",
+                    borderTop: "2px solid rgb(239,239,239)",
                 }}
             >
                 <div
                     style={{
                         display: "flex",
                         alignItems: "center",
-                        justifyContent: "center",
-                        marginTop: "1px",
+                        justifyContent: "left",
                         flex: 1,
                     }}
                 >
-                    <RawSerialOut />
+                    <RawSerialOut
+                        text={text}
+                        setText={setText}
+                        consoleSendCommand={consoleSendCommand}
+                        codeHistIndex={codeHistIndex}
+                        setCodeHistIndex={setCodeHistIndex}
+                    />
                 </div>
                 <div
                     style={{
                         display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        width: "200px",
+                        alignItems: "end",
+                        justifyContent: "right",
                     }}
                 >
-                    D - Footer Right
-                    {/* <Button onClick={consoleSendCommand}>Send</Button> */}
+                    <Button onClick={consoleSendCommand}>Send</Button>
                 </div>
             </div>
         </div>

--- a/src/tabs/RawConsole.jsx
+++ b/src/tabs/RawConsole.jsx
@@ -23,6 +23,7 @@ import useSerialCommands from "../serial/useSerialCommands";
 // toolbar
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
+import { Menu } from "../layout/Menu";
 
 const RawSerialIn = () => {
     // "in" to computer, "out" from microcontroller
@@ -207,9 +208,24 @@ const RawConsole = () => {
         setCodeHistIndex(-1);
         setText("");
     }
+    const hiddenMenuLabelOptions = [
+        {
+            text: "Clear",
+            handler: () => {
+                console.log("Clear");
+            },
+        },
+        {
+            text: "Connect",
+            handler: () => {
+                console.log("Connect");
+                connect();
+            },
+        },
+    ];
 
     return ready ? (
-        <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div style={{ display: "flex", flexDirection: "column", height: "100%", overflowX: "hidden" }}>
             <div
                 style={{
                     display: "flex",
@@ -246,6 +262,7 @@ const RawConsole = () => {
                                 <Button onClick={sendCtrlD}>Ctrl-D</Button>
                             </Tooltip>
                         </ToolbarEntry>
+                        <Menu label="⋮" options={hiddenMenuLabelOptions} />
                     </Toolbar>
                 </div>
             </div>

--- a/src/tabs/RawConsole.jsx
+++ b/src/tabs/RawConsole.jsx
@@ -25,7 +25,7 @@ import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import { Menu } from "../layout/Menu";
 
-const RawSerialIn = () => {
+const RawSerialIn = ({ startIndex, setCurrentLength }) => {
     // "in" to computer, "out" from microcontroller
     const { config, serialOutput } = useContext(ideContext);
     let output = removeInBetween(serialOutput, constants.TITLE_START, constants.TITLE_END);
@@ -33,8 +33,12 @@ const RawSerialIn = () => {
     if (config.raw_console.hide_cv) {
         output = removeInBetween(output, constants.CV_JSON_START, constants.CV_JSON_END);
     }
-
-    return <pre style={{ whiteSpace: "pre-wrap", fontSize: config.raw_console.font + "pt" }}>{output}</pre>;
+    setCurrentLength(output.length);
+    return (
+        <pre style={{ whiteSpace: "pre-wrap", fontSize: config.raw_console.font + "pt" }}>
+            {output.slice(startIndex)}
+        </pre>
+    );
 };
 
 const RawSerialOut = ({ text, setText, codeHistIndex, setCodeHistIndex, consoleSendCommand }) => {
@@ -195,10 +199,14 @@ function ToolbarEntry({ children, fixedWidth = null }) {
 
 const RawConsole = () => {
     const { sendCtrlC, sendCtrlD, sendCode, codeHistory } = useSerialCommands();
+    const { serialTitle } = useContext(ideContext);
+    // Serial Out states
     const { serialReady: ready, connectToSerialPort: connect } = useContext(ideContext);
     const [text, setText] = useState("");
     const [codeHistIndex, setCodeHistIndex] = useState(-1);
-    const { serialTitle } = useContext(ideContext);
+    // Serial In states
+    const [startIndex, setStartIndex] = useState(0);
+    const [currentLength, setCurrentLength] = useState(0);
 
     function consoleSendCommand() {
         if (text.trim().length === 0) {
@@ -213,6 +221,7 @@ const RawConsole = () => {
             text: "Clear",
             handler: () => {
                 console.log("Clear");
+                setStartIndex(currentLength);
             },
         },
         {
@@ -274,7 +283,7 @@ const RawConsole = () => {
                         display: "flex",
                     }}
                 >
-                    <RawSerialIn />
+                    <RawSerialIn startIndex={startIndex} setCurrentLength={setCurrentLength} />
                 </ScrollableFeed>
             </div>
             <div

--- a/src/tabs/RawConsole.jsx
+++ b/src/tabs/RawConsole.jsx
@@ -20,6 +20,9 @@ import Button from "@mui/material/Button";
 import ideContext from "../ideContext";
 // commands
 import useSerialCommands from "../serial/useSerialCommands";
+// toolbar
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
 
 const RawSerialIn = () => {
     // "in" to computer, "out" from microcontroller
@@ -218,15 +221,88 @@ const RawSerialOut = () => {
     );
 };
 
+// toolbar
+function ToolbarEntry({ children, fixedWidth = null }) {
+    const sx = {
+        flexGrow: 1,
+        pl: 1,
+        fontSize: "14px",
+    };
+
+    if (fixedWidth) {
+        sx.width = fixedWidth;
+    }
+
+    return (
+        <Typography component="div" noWrap={true} sx={sx}>
+            {children}
+        </Typography>
+    );
+}
+
 const RawConsole = () => {
     const { serialReady: ready, connectToSerialPort: connect } = useContext(ideContext);
     return ready ? (
-        <Box sx={{ height: "100%" }}>
-            <ScrollableFeed>
-                <RawSerialIn />
-                <RawSerialOut />
-            </ScrollableFeed>
-        </Box>
+        <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "left",
+                    width: "100%",
+                    borderBottomColor: "rgb(239,239,239)",
+                    borderBottom: "solid",
+                }}
+            >
+                <Toolbar variant="dense" disableGutters={true} sx={{ minHeight: "35px", maxHeight: "35px" }}>
+                    <ToolbarEntry>hi</ToolbarEntry>
+                </Toolbar>
+            </div>
+
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "auto" }}>
+                {" "}
+                {/* Ensures B is scrollable if content overflows */}
+                <ScrollableFeed
+                    style={{
+                        flexShrink: 0,
+                        display: "flex",
+                    }}
+                >
+                    <RawSerialIn />
+                </ScrollableFeed>
+            </div>
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    borderTopColor: "rgb(239,239,239)",
+                    borderTop: "solid",
+                }}
+            >
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        marginTop: "1px",
+                        flex: 1,
+                    }}
+                >
+                    <RawSerialOut />
+                </div>
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        width: "200px",
+                    }}
+                >
+                    D - Footer Right
+                    {/* <Button onClick={consoleSendCommand}>Send</Button> */}
+                </div>
+            </div>
+        </div>
     ) : (
         <Button onClick={connect}>Connect to Serial Port</Button>
     );


### PR DESCRIPTION
Issue https://github.com/urfdvw/CircuitPython-online-IDE2/issues/7

# What is changed
## Raw Console

Basic part
- Removed the bubble
- Created a Toolbar with Ctrl-C Ctrl-D
- Moved the send button to the right bottom corner.

Enhancement
- Include the serial title in the toolbar
    - Add option to hide/show serial title in the status bar, to reduce confusion
- Add 2nd layer options
    - clear
    - connect 
   
## MISC
- Move the label of console tab closer to the tab content in the initial view
    - was: tab was in the middle area, but the label was in the left bottom corner
    - now: moved the tab out of the bottom border and into a tabset.
- Navigation tab: remove un-necessary scroll bar.
- clear console is just to choose a start point of the display.
- fix bug: change states when serial physically disconnects