### PR TITLE
fix issue #12

### DIFF
--- a/src/IdeBody.jsx
+++ b/src/IdeBody.jsx
@@ -56,7 +56,9 @@ export default function IdeBody() {
                 FlexLayout.Actions.addNode(
                     { type: "tab", name: fileName, component: "editor", config: { fileKey: fileKey } },
 
-                    model.getActiveTabset() ? model.getActiveTabset().getId() : "initial_tabset",
+                    model.getActiveTabset()
+                        ? model.getActiveTabset().getId()
+                        : model.getRoot().getChildren()[0].getId(), // there should be at least one tabset
                     FlexLayout.DockLocation.CENTER,
                     -1
                 )

--- a/src/layout/layout.json
+++ b/src/layout/layout.json
@@ -45,7 +45,6 @@
         "children": [
             {
                 "type": "tabset",
-                "id": "initial_tabset",
                 "weight": 50,
                 "selected": 0,
                 "children": [
@@ -59,7 +58,6 @@
             },
             {
                 "type": "tabset",
-                "id": "initial_tabset_2",
                 "weight": 50,
                 "selected": 0,
                 "children": [


### PR DESCRIPTION
issue: https://github.com/urfdvw/CircuitPython-online-IDE2/issues/12

In case of no active tabset,
instead looking for a specific tabset id,
looking for the first child of the root node, which is a tabset,
because there must be at least one tabset.