### PR TITLE
[#18] Editor file delete indicator

### DIFF
--- a/src/react-local-file-system/components/ContentEntry.jsx
+++ b/src/react-local-file-system/components/ContentEntry.jsx
@@ -70,7 +70,11 @@ export default function ContentEntry({ entryHandle }) {
                     return;
                 }
                 setIsLoading(true);
-                await removeEntry(currentFolderHandle, entryHandle);
+                try {
+                    await removeEntry(currentFolderHandle, entryHandle);
+                } catch {
+                    console.warn("remove file failed");
+                }
                 await showFolderView(currentFolderHandle);
                 setIsLoading(false);
             },

--- a/src/react-local-file-system/utilities/fileSystemUtils.js
+++ b/src/react-local-file-system/utilities/fileSystemUtils.js
@@ -48,6 +48,18 @@ export async function isEntryHealthy(entryHandle) {
     }
 }
 
+export async function isfileSame(entryHandle, text) {
+    if (entryHandle === null) {
+        return false;
+    }
+    try {
+        const fileText = await getFileText(entryHandle);
+        return text === fileText;
+    } catch {
+        return false;
+    }
+}
+
 export async function getFolderContent(folderHandle, withParent = false) {
     const layer = [];
     if (withParent && folderHandle.parent) {

--- a/src/tabs/IdeEditor.jsx
+++ b/src/tabs/IdeEditor.jsx
@@ -16,7 +16,7 @@ import Tooltip from "@mui/material/Tooltip";
 // Layout
 import PopUp from "../layout/PopUp";
 // file utils
-import { getFileText, writeFileText } from "../react-local-file-system";
+import { getFileText, writeFileText, isEntryHealthy } from "../react-local-file-system";
 // context
 import ideContext from "../ideContext";
 // commands
@@ -37,6 +37,15 @@ export default function IdeEditor({ fileHandle, node }) {
     const [text, setText] = useState("");
     const [fileEdited, setFileEdited] = useState(false);
     const [popped, setPopped] = useState(false);
+    const [fileExists, setFileExists] = useState(true);
+    // directoryReady
+    useEffect(() => {
+        const interval = setInterval(async () => {
+            setFileExists(await isEntryHealthy(fileHandle));
+        }, 1000);
+        return () => clearInterval(interval);
+    }, [fileHandle]);
+
     useEffect(() => {
         const name = (fileEdited ? FILE_EDITED : "") + fileHandle.name;
         node.getModel().doAction(FlexLayout.Actions.renameTab(node.getId(), name));
@@ -229,6 +238,7 @@ export default function IdeEditor({ fileHandle, node }) {
                         }}
                     >
                         Editor: {fileHandle.fullPath}
+                        {fileExists ? "" : " (deleted)"}
                     </div>
                     <div
                         style={{


### PR DESCRIPTION
This PR solved the Issue in a different way than proposed.
instead of preventing removal of a file,
deleted files are remained in the editor but given an indicator saying this file is deleted.
This will include removal, moving and renaming the file.
Saving the test in the editor will recreate the file.

MISC
- Edited indicator is re-done in the same way, so that undo can revert the edited indicator
- Added try-catch to removal of file